### PR TITLE
Include MPL license notice in optimize.php

### DIFF
--- a/optimize.php
+++ b/optimize.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 //Polyfill str_contains for PHP versions < 8
 if (!function_exists('str_contains')) {
     function str_contains(string $haystack, string $needle): bool


### PR DESCRIPTION
This pull requests adds information about the license used with this repository. Helpful if the file is used by someone who only copied the `optimize.php` file, as it lets them know what they can or can't do with this file.
```
1.4. "Covered Software"
    means Source Code Form to which the initial Contributor has attached
    the notice in Exhibit A, the Executable Form of such Source Code
    Form, and Modifications of such Source Code Form, in each case
    including portions thereof.


Exhibit A - Source Code Form License Notice
-------------------------------------------

  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at http://mozilla.org/MPL/2.0/.

```